### PR TITLE
added default option to get_prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Dict{Symbol,Any} with 2 entries:
 julia> get_prop(mg, 2, :name)
 "John"
 
+# set a default value to return in case the property does not exist
+julia> get_prop(mg, 2, :nonexistent_prop, "default value")
+"default value"
+
 # delete a specific property
 julia> rem_prop!(mg, 1, :name)
 Dict{Symbol,Any} with 1 entry:

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -269,25 +269,13 @@ Return the property `prop` defined for graph `g`, vertex `v`, or edge `e`
 Use the version with `default`, to return a default value if the property is not defined. Otherwise, it will return an error.
 """
 get_prop(g::AbstractMetaGraph, prop::Symbol) = props(g)[prop]
-get_prop(g::AbstractMetaGraph, prop::Symbol, default) = has_prop(g, prop) ? get_prop(g, prop) : default
+get_prop(g::AbstractMetaGraph, prop::Symbol, default) = get(props(g), prop, default)
 
 get_prop(g::AbstractMetaGraph, v::Integer, prop::Symbol) = props(g, v)[prop]
-function get_prop(g::AbstractMetaGraph, v::Integer, prop::Symbol, default)
-    if has_vertex(g, v)
-        return has_prop(g, v, prop) ? get_prop(g, v, prop) : default
-    else
-        throw(ArgumentError("Vertex $v not in graph"))
-    end
-end
+get_prop(g::AbstractMetaGraph, v::Integer, prop::Symbol, default) = get(props(g, v), prop, default)
 
 get_prop(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol) = props(g, e)[prop]
-function get_prop(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol, default)
-    if has_edge(g, e)
-        has_prop(g, e, prop) ? get_prop(g, e, prop) : default
-    else
-        throw(ArgumentError("$e not in graph"))
-    end
-end
+get_prop(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol, default) = get(props(g, e), prop, default)
 
 get_prop(g::AbstractMetaGraph, u::Integer, v::Integer, prop::Symbol) = get_prop(g, Edge(u, v), prop)
 get_prop(g::AbstractMetaGraph, u::Integer, v::Integer, prop::Symbol, default) = get_prop(g, Edge(u, v), prop, default)

--- a/src/MetaGraphs.jl
+++ b/src/MetaGraphs.jl
@@ -253,20 +253,33 @@ props(g::AbstractMetaGraph, v::Integer) = get(PropDict, g.vprops, v)
 props(g::AbstractMetaGraph, u::Integer, v::Integer) = props(g, Edge(u, v))
 
 """
-    get_prop(g, prop)
-    get_prop(g, v, prop)
-    get_prop(g, e, prop)
-    get_prop(g, s, d, prop)
+    get_prop(g, prop::Symbol)
+    get_prop(g, prop::Symbol, default)
+
+    get_prop(g, v, prop::Symbol)
+    get_prop(g, v, prop::Symbol, default)
+
+    get_prop(g, e, prop::Symbol)
+    get_prop(g, e, prop::Symbol, default)
+    get_prop(g, s, d, prop::Symbol)
+    get_prop(g, s, d, prop::Symbol, default)
 
 Return the property `prop` defined for graph `g`, vertex `v`, or edge `e`
 (optionally referenced by source vertex `s` and destination vertex `d`).
-If property is not defined, return an error.
+Use the version with `default`, to return a default value if the property is not defined. Otherwise, it will return an error.
 """
 get_prop(g::AbstractMetaGraph, prop::Symbol) = props(g)[prop]
+get_prop(g::AbstractMetaGraph, prop::Symbol, default) = has_prop(g, prop) ? get_prop(g, prop) : default
+
 get_prop(g::AbstractMetaGraph, v::Integer, prop::Symbol) = props(g, v)[prop]
+get_prop(g::AbstractMetaGraph, v::Integer, prop::Symbol, default) = has_prop(g, v, prop) ? get_prop(g, v, prop) : default
+
 get_prop(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol) = props(g, e)[prop]
+get_prop(g::AbstractMetaGraph, e::SimpleEdge, prop::Symbol, default) = has_prop(g, e, prop) ? get_prop(g, e, prop) : default
 
 get_prop(g::AbstractMetaGraph, u::Integer, v::Integer, prop::Symbol) = get_prop(g, Edge(u, v), prop)
+get_prop(g::AbstractMetaGraph, u::Integer, v::Integer, prop::Symbol, default) = has_prop(g, u, v, prop) ? get_prop(g, u, v, prop) : default
+
 
 """
     has_prop(g, prop)

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -83,19 +83,19 @@ import Base64:
         set_prop!(mg, nv(mg), :testprop, "exists")
         @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
         @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
-        @test_throws ArgumentError get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent")
+        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
 
         # edges
         set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
         @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test_throws ArgumentError get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters")
+        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
         @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
 
         @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test_throws ArgumentError get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters")
+        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
         @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
 
@@ -103,7 +103,6 @@ import Base64:
         set_prop!(mg, :testgraphpprop, "linegraph")
         @test get_prop(mg, :testgraphpprop, "circlegraph") == "linegraph"
         @test get_prop(mg, :testgraphpprop_nonexist, "circlegraph") == "circlegraph"
-
     end
 
     for g in testdigraphs(dgx)
@@ -167,21 +166,21 @@ import Base64:
         set_prop!(mg, nv(mg), :testprop, "exists")
         @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
         @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
-        @test_throws ArgumentError get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent")
+        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
 
         # edges
         set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
         @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test_throws ArgumentError get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters")
-        @test_throws ArgumentError get_prop(mg, 2, 1, :testedgeprop, "0 meters")
-        @test_throws ArgumentError get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters")
+        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
 
         @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test_throws ArgumentError get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters")
-        @test_throws ArgumentError get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters")
-        @test_throws ArgumentError get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters")
+        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
 
         # graph
         set_prop!(mg, :testgraphpprop, "linegraph")

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -78,6 +78,32 @@ import Base64:
         U = @inferred(weighttype(mg))
         @test @inferred(nv(MetaGraph{T,U}(6))) == 6
 
+        # get_prop with default argument
+        # vertices
+        set_prop!(mg, nv(mg), :testprop, "exists")
+        @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
+        @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
+        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
+
+        # edges
+        set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
+        @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
+
+        @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
+
+        # graph
+        set_prop!(mg, :testgraphpprop, "linegraph")
+        @test get_prop(mg, :testgraphpprop, "circlegraph") == "linegraph"
+        @test get_prop(mg, :testgraphpprop_nonexist, "circlegraph") == "circlegraph"
+
     end
 
     for g in testdigraphs(dgx)
@@ -135,6 +161,32 @@ import Base64:
         T = @inferred(eltype(mg))
         U = @inferred(weighttype(mg))
         @test @inferred(nv(MetaDiGraph{T,U}(6))) == 6
+
+        # get_prop with default argument
+        # vertices
+        set_prop!(mg, nv(mg), :testprop, "exists")
+        @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
+        @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
+        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
+
+        # edges
+        set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
+        @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "0 meters"
+        @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
+
+        @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
+        @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "0 meters"
+        @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
+
+        # graph
+        set_prop!(mg, :testgraphpprop, "linegraph")
+        @test get_prop(mg, :testgraphpprop, "circlegraph") == "linegraph"
+        @test get_prop(mg, :testgraphpprop_nonexist, "circlegraph") == "circlegraph"
     end
 
     for gbig in [SimpleGraph(0xff), SimpleDiGraph(0xff)]

--- a/test/metagraphs.jl
+++ b/test/metagraphs.jl
@@ -1,7 +1,7 @@
 using MetaGraphs
 import Graphs: SimpleGraphs
 import Base64:
-        stringmime
+    stringmime
 
 
 @testset "MetaGraphs" begin
@@ -21,7 +21,7 @@ import Base64:
     mg = MetaGraph()
     @test add_vertex!(mg, :color, "red") && get_prop(mg, nv(mg), :color) == "red"
     @test add_vertex!(mg, Dict(:color => "red", :prop2 => "prop2")) && props(mg, nv(mg)) == Dict(:color => "red", :prop2 => "prop2")
-    @test add_edge!(mg, 1, 2, :color, "blue") && get_prop(mg, 1, 2, :color) ==  "blue"
+    @test add_edge!(mg, 1, 2, :color, "blue") && get_prop(mg, 1, 2, :color) == "blue"
     @test add_vertex!(mg) && add_edge!(mg, 1, 3, Dict(:color => "red", :prop2 => "prop2")) && props(mg, 1, 3) == Dict(:color => "red", :prop2 => "prop2")
 
     for g in testgraphs(gx)
@@ -83,19 +83,19 @@ import Base64:
         set_prop!(mg, nv(mg), :testprop, "exists")
         @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
         @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
-        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
+        @test_throws ArgumentError get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent")
 
         # edges
         set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
         @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test_throws ArgumentError get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters")
         @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
 
         @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test_throws ArgumentError get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters")
         @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
 
@@ -167,21 +167,21 @@ import Base64:
         set_prop!(mg, nv(mg), :testprop, "exists")
         @test get_prop(mg, nv(mg), :testprop, "nonexistent") == "exists"
         @test get_prop(mg, nv(mg), :testprop_nonexist, "nonexistent") == "nonexistent"
-        @test get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent") == "nonexistent"
+        @test_throws ArgumentError get_prop(mg, nv(mg) + 100, :testprop_nonexist, "nonexistent")
 
         # edges
         set_prop!(mg, 1, 2, :testedgeprop, "5 meters")
         @test get_prop(mg, 1, 2, :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, 1, 2, :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, 2, 1, :testedgeprop, "0 meters") == "0 meters"
-        @test get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test_throws ArgumentError get_prop(mg, 2, 4, :testedgeprop_nonexist, "0 meters")
+        @test_throws ArgumentError get_prop(mg, 2, 1, :testedgeprop, "0 meters")
+        @test_throws ArgumentError get_prop(mg, 2, 1, :testedgeprop_nonexist, "0 meters")
 
         @test get_prop(mg, Edge(1, 2), :testedgeprop, "0 meters") == "5 meters"
         @test get_prop(mg, Edge(1, 2), :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters") == "0 meters"
-        @test get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters") == "0 meters"
-        @test get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters") == "0 meters"
+        @test_throws ArgumentError get_prop(mg, Edge(2, 4), :testedgeprop_nonexist, "0 meters")
+        @test_throws ArgumentError get_prop(mg, Edge(2, 1), :testedgeprop, "0 meters")
+        @test_throws ArgumentError get_prop(mg, Edge(2, 1), :testedgeprop_nonexist, "0 meters")
 
         # graph
         set_prop!(mg, :testgraphpprop, "linegraph")
@@ -351,7 +351,7 @@ import Base64:
     @test weightfield!(mg, :weight) == :weight
     @test enumerate_paths(dijkstra_shortest_paths(mg, 1), 3) == [1, 2, 3]
 
-    @test set_props!(mg, 1, 2,  Dict(:color => :blue, :action => "knows"))
+    @test set_props!(mg, 1, 2, Dict(:color => :blue, :action => "knows"))
     @test length(props(mg, 1, 2)) == 3
     @test rem_edge!(mg, 1, 2)
     @test length(props(mg, 1, 2)) == 0
@@ -404,12 +404,12 @@ import Base64:
     for v in vertices(mga)
         set_prop!(mga, v, :name, string(v))
     end
-    set_indexing_prop!(mga,:name)
+    set_indexing_prop!(mga, :name)
     @test get_prop(mga, 1, :name) == "1"
     @test get_prop(mga, 5, :name) == "5"
     @test rem_vertex!(mga, 1)
     @test get_prop(mga, 1, :name) == "5"
-    @test mga["5",:name] == 1
+    @test mga["5", :name] == 1
     @test isempty(props(mga, 5))
 
     # test for #22
@@ -425,19 +425,19 @@ import Base64:
 
     # test for #72 - Multiple indicies that are not all used
     let
-        test_graph = x-> begin
-            g=MetaGraph()
-            set_indexing_prop!(g,:IndexA)
-            set_indexing_prop!(g,:IndexB)
-            add_vertex!(g,:IndexA,"A")
-            x && add_vertex!(g,:IndexA,"B")
-            x && set_indexing_prop!(g,nv(g),:IndexB,"B")
-            add_vertex!(g,:IndexB,"C")
+        test_graph = x -> begin
+            g = MetaGraph()
+            set_indexing_prop!(g, :IndexA)
+            set_indexing_prop!(g, :IndexB)
+            add_vertex!(g, :IndexA, "A")
+            x && add_vertex!(g, :IndexA, "B")
+            x && set_indexing_prop!(g, nv(g), :IndexB, "B")
+            add_vertex!(g, :IndexB, "C")
             g
         end
-        mga=test_graph(true)
-        rem_vertex!(mga,2)
-        @test mga==test_graph(false)
+        mga = test_graph(true)
+        rem_vertex!(mga, 2)
+        @test mga == test_graph(false)
     end
 
     mga = MetaDiGraph(path_digraph(4))
@@ -534,7 +534,7 @@ end
     @test MetaGraphs.index_available(dG, 7, :name, "dgnode_8-anothername") == true
 
     @test_throws ErrorException set_props!(G, 11, Dict(:name => "gnode_3", :other_name => "something11"))
-    @test_throws ErrorException set_props!(dG,11, Dict(:name => "dgnode_3", :other_name => "something11"))
+    @test_throws ErrorException set_props!(dG, 11, Dict(:name => "dgnode_3", :other_name => "something11"))
     @test_throws KeyError get_prop(G, 11, :other_name)
     @test_throws KeyError get_prop(dG, 11, :other_name)
 


### PR DESCRIPTION
Had to use the `has_prop(g, e, :prop) ? get_prop(g, e, :prop) : default_value` pattern way too much, found issue #37, and decided to fix this problem. Here is my very simple solution.

Given that the default value has a type, we could maybe even do something like:
`get_prop(g, e, prop, default::T)::T where T = has_prop(....) ? get_prop(....) : default`
making it typestable, which could be nice.
On the other hand, this would exclude all the cases, where properties can have wildly different types from using this feature. Given that `MetaGraphsNext.jl` is the typestable successor to this package, it might be nice to not constrain the users in that way.

Not sure though. What do you think?