### PR TITLE
try for a compat backport of JLD2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MetaGraphs"
 uuid = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Graphs = "1.4"
-JLD2 = "0.1.11, 0.2, 0.3, 0.4"
+JLD2 = "0.1.11, 0.2, 0.3, 0.4, 0.5, 0.6"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This PR backports the JLD2 compat bound to the latest v0.6 versions.

This should not be necessary but there are downstream packages with hard to reach authors (LightOSM) which still depend on MetaGraphs v0.7 and I think it will be quicker to release a patch of MetaGraphs than to get a new LightOSM release out.

Core problem is that old JLD2 does not compile on julia v1.12 and therefore the MetaGraphs v0.7 series does not compile on v1.12  and neither do any of the downstream packages.


---
Actually, this PR should not point to master but to a dedicated backport branch from which we can tag a patch release.